### PR TITLE
fix: 보스 오브젝트 null 참조 크래시 방지

### DIFF
--- a/Assets/Script/Character/CharacterMove.cs
+++ b/Assets/Script/Character/CharacterMove.cs
@@ -59,6 +59,8 @@ public class CharacterMove : MonoBehaviour
         rb = GetComponent<Rigidbody>();
         HealParticle.Stop();
         boss = GameObject.FindWithTag("Boss");
+        if (boss == null)
+            Debug.LogError("[CharacterMove] 'Boss' 태그를 가진 오브젝트를 찾을 수 없습니다.");
 
         move = InputSystem.actions.FindAction("Move", true);
         look = InputSystem.actions.FindAction("Look", true);
@@ -160,6 +162,7 @@ public class CharacterMove : MonoBehaviour
 
     private void BossLockOn(InputAction.CallbackContext context)
     {
+        if (boss == null) return;
         lockOn = !lockOn;
         LockOnPoint.SetActive(lockOn);
     }
@@ -173,8 +176,16 @@ public class CharacterMove : MonoBehaviour
 
         if (lockOn)
         {
-            transform.LookAt(boss.transform);
-            DodgeView.transform.LookAt(boss.transform);
+            if (boss == null || !boss.activeInHierarchy)
+            {
+                lockOn = false;
+                LockOnPoint.SetActive(false);
+            }
+            else
+            {
+                transform.LookAt(boss.transform);
+                DodgeView.transform.LookAt(boss.transform);
+            }
         }
 
         if (

--- a/Assets/Script/Character/CharacterState.cs
+++ b/Assets/Script/Character/CharacterState.cs
@@ -180,6 +180,8 @@ public class CharacterState : MonoBehaviour, IDamageable
 
         characterMove = GetComponent<CharacterMove>();
         boss = GameObject.FindGameObjectWithTag(BossTag);
+        if (boss == null)
+            Debug.LogError($"[CharacterState] '{BossTag}' 태그를 가진 오브젝트를 찾을 수 없습니다.");
         anim = GetComponent<Animator>();
     }
 


### PR DESCRIPTION
## 관련 이슈
Closes #115

## 변경 사항

### `CharacterState.cs`
- `FindGameObjectWithTag` 결과가 null이면 `Debug.LogError`로 명시적 에러 출력

### `CharacterMove.cs`
- `Start()`: boss null 시 에러 로그 추가
- `BossLockOn()`: `boss == null`이면 락온 토글 차단
- `FixedUpdate()`: 락온 중 보스가 null이거나 비활성화(`activeInHierarchy == false`)되면 락온 자동 해제

## 테스트 항목
- [ ] 보스 오브젝트가 없는 씬에서 플레이 시작 시 에러 로그 출력, 크래시 없음
- [ ] 락온 키 입력 시 보스 없으면 락온 미활성화
- [ ] 보스 사망 후 락온 자동 해제 확인