### PR TITLE
fix: 스태미나 회복 공식 수정 (#117)

### DIFF
--- a/Assets/Script/Character/CharacterState.cs
+++ b/Assets/Script/Character/CharacterState.cs
@@ -199,18 +199,8 @@ public class CharacterState : MonoBehaviour, IDamageable
         }
         if (CanRestoreStm && currentStamina < maxStamina)
         {
-            var duration = 0f;
-
-            if (CurrentStamina <= 0f)
-            {
-                duration = 0.1f;
-            }
-            else
-            {
-                duration = stmRecoverTime * (CurrentStamina / maxStamina);
-            }
-
-            CurrentStamina += Mathf.Lerp(0, maxStamina, Time.deltaTime * duration);
+            float recoveryPerSecond = maxStamina / stmRecoverTime;
+            CurrentStamina += recoveryPerSecond * Time.deltaTime;
         }
 
         float DodgeRemain = DodgeCooldownRemaining;


### PR DESCRIPTION
## Summary

- `CharacterState.cs:213`의 `Mathf.Lerp(0, maxStamina, Time.deltaTime * duration)` 오용을 제거
- 매 프레임 독립 계산으로 누적이 안 되던 문제를 선형 회복(`maxStamina / stmRecoverTime * Time.deltaTime`)으로 교체
- 스태미나가 낮을수록 더 느리게 회복되던 비직관적 비례 로직도 제거 — 이제 일정한 속도로 회복

Closes #117

## Test plan

- [ ] Unity Editor에서 `MainScene.unity` 또는 `CharacterSampleScene.unity` 열기
- [ ] 플레이 모드 진입, 공격(−10) 또는 구르기(−20)로 스태미나 소모
- [ ] `restoreStmTime`(=3초) 대기 후 회복 시작 확인
- [ ] 회복이 선형적으로 일어나며, `stmRecoverTime` 값에 따른 회복 시간이 일치하는지 확인 (현재 Inspector 값 `1` → 1초에 100 회복)
- [ ] 스태미나 0에서도 정상 회복되는지 확인
- [ ] 회복 중 공격/구르기 소모 시 `restoreStmTimer` 재설정으로 회복이 일시 정지되는지 확인
- [ ] ⚠️ `stmRecoverTime = 1`이면 회복이 매우 빠르므로, 플레이테스트 후 Inspector 값 조정 권장 (예: `3`~`5`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)