### PR TITLE
fix: Boss.cs — target(플레이어) null 참조 가드 추가

### DIFF
--- a/Assets/Script/Boss/Boss.cs
+++ b/Assets/Script/Boss/Boss.cs
@@ -37,7 +37,7 @@ public class Boss : MonoBehaviour, IDamageable
     public float idleInterval = 4f;
     public float attackDistance = 0f;
     private float toTargetDistance =>
-        Vector3.Distance(transform.position, target.transform.position);
+        target != null ? Vector3.Distance(transform.position, target.transform.position) : float.MaxValue;
     private float attackCoolTime = 0f;
     public float attackInterval = 4f;
     private float forwardAttackCoolTime = 0f; //��������
@@ -105,7 +105,11 @@ public class Boss : MonoBehaviour, IDamageable
 
         target = GameObject.FindGameObjectWithTag(PlayerTag);
 
-        if (target != null)
+        if (target == null)
+        {
+            Debug.LogError($"[Boss] '{PlayerTag}' 태그를 가진 오브젝트를 찾을 수 없습니다.");
+        }
+        else
         {
             target.GetComponent<CharacterState>().OnGameOver += OnGameOver;
         }


### PR DESCRIPTION
## 관련 이슈
Closes #138

## 변경 사항

### `Boss.cs`
- `Start()`: `FindGameObjectWithTag` 결과 null 시 `Debug.LogError`로 명시적 에러 출력
- `toTargetDistance` 프로퍼티: null 가드 추가 — target이 null이면 `float.MaxValue` 반환해 거리 기반 상태 전환이 오작동 없이 스킵됨

## 변경하지 않은 이유
- `Update():127`, `FixedUpdate():218`, `OnGameOver():436`, `OnDisable():446` — 이미 `target == null` 가드가 있어 수정 불필요

## 테스트 항목
- [ ] 플레이어 오브젝트가 없는 씬에서 보스 시작 시 에러 로그 출력, 크래시 없음
- [ ] target null 상태에서 보스가 Idle 상태로 멈춰 있고 이동/공격 시도하지 않음